### PR TITLE
Fix for binary data in bulk encode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hiredis"]
 	path = hiredis
-	url = git://github.com/antirez/hiredis
+	url = git://github.com/redis/hiredis

--- a/MANIFEST
+++ b/MANIFEST
@@ -8,8 +8,6 @@ hiredis/net.h
 hiredis/README.md
 hiredis/sds.c
 hiredis/sds.h
-hiredis/TODO
-hiredis/util.h
 lib/Protocol/Redis/XS.pm
 Makefile.PL
 MANIFEST			This list of files

--- a/t/xs.t
+++ b/t/xs.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 6;
 
 use Protocol::Redis::XS;
 my $redis = new_ok 'Protocol::Redis::XS', [api => 1];
@@ -12,4 +12,7 @@ like $@, qr/Not a CODE reference/, "Die on invalid callback";
 $redis->on_message(undef);
 $redis->parse(":1234567891234567890\r\n");
 is $redis->get_message->{data}, 1234567891234567890, "Large integer is correct";
+is $redis->encode({type => '*', data => [{type => '$', data => "\x00TEST\x00"}]}), "*1\r\n\$6\r\n\x00TEST\x00\r\n", 'Binary data';
+is $redis->encode({type => '$', data => "\x00"}), "\$1\r\n\x00\r\n", 'Encode bulk single nul character';
+is $redis->encode({type => '$', data => undef}), "\$-1\r\n", 'Encode bulk undef data';
 


### PR DESCRIPTION
Under Protocol::Redis::XS any null character in 'data' causes a failure in encodeBulk.  There is no such failure in Protocol::Redis.