### PR TITLE
use Alien::hiredis instead of bundled hiredis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pm_to_blib
 *.o
 XS.bs
 XS.c
+/Protocol-Redis-XS-*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "hiredis"]
-	path = hiredis
-	url = git://github.com/redis/hiredis

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,13 +1,4 @@
 Changes
-hiredis/COPYING			Just a selection of hiredis's files are shipped
-hiredis/fmacros.h
-hiredis/hiredis.c
-hiredis/hiredis.h
-hiredis/net.c
-hiredis/net.h
-hiredis/README.md
-hiredis/sds.c
-hiredis/sds.h
 lib/Protocol/Redis/XS.pm
 Makefile.PL
 MANIFEST			This list of files

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -34,9 +34,9 @@
 
 .*\.o$
 ^[^/]+\.c$
-^hiredis/(async|adapters|example|dict|test|Makefile)
 .*\.bs$
 .*\.gz$
 
 .*\.so$
 MYMETA.yml
+MYMETA.json

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,15 +3,7 @@ use warnings;
 use ExtUtils::MakeMaker 6.31;
 use ExtUtils::Depends;
 
-my $pkg = ExtUtils::Depends->new("Protocol::Redis::XS", "XS::Object::Magic");
-$pkg->set_inc("-Ihiredis");
-my %dep = $pkg->get_makefile_vars;
-
-# Workaround bugs in the toolchain so we can actually build things in
-# directories.
-my $my_xs = q[XS$(OBJ_EXT)];
-my @hiredis_files = map "$_\$(OBJ_EXT)", qw(hiredis sds net);
-my $hiredis_obj = join " ", map 'hiredis/' . $_, @hiredis_files;
+my $pkg = ExtUtils::Depends->new("Protocol::Redis::XS", "XS::Object::Magic", "Alien::hiredis");
 
 my %WriteMakefile_args = (
   NAME          => 'Protocol::Redis::XS',
@@ -24,6 +16,8 @@ my %WriteMakefile_args = (
     'ExtUtils::MakeMaker' => '6.31',
     'ExtUtils::Depends' => 0,
     'XS::Object::Magic' => 0,
+    'Alien::Base' => '1.65', # ExtUtils::Depends compatibility
+    'Alien::hiredis' => '0.003',
   },
 
   TEST_REQUIRES => {
@@ -38,10 +32,7 @@ my %WriteMakefile_args = (
     'parent' => 0,
   },
 
-  INC      => $dep{INC},
-  TYPEMAPS => $dep{TYPEMAPS},
-  OBJECT   => "$my_xs $hiredis_obj",
-  LDFROM   => "$my_xs " . join(" ", @hiredis_files),
+  $pkg->get_makefile_vars,
 
   META_MERGE => {
     'meta-spec'    => { version => 2 },

--- a/README
+++ b/README
@@ -53,12 +53,6 @@ SUPPORT
 DEVELOPMENT
     See github: <https://github.com/dgl/protocol-redis-xs>.
 
-    Developer note, hiredis is pulled in via a git submodule, run:
-
-     git submodule update --init
-
-    to make the development version buildable.
-
 AUTHOR
     David Leadbeater <dgl@dgl.cx>
 
@@ -73,9 +67,6 @@ COPYRIGHT AND LICENSE
     by the Free Software Foundation; or the Artistic License.
 
     See http://dev.perl.org/licenses/ for more information.
-
-    The hiredis library included in this distribution has a seperate license
-    (3 clause BSD). See hiredis/COPYING.
 
 SEE ALSO
     Redis, Redis::hiredis, AnyEvent::Redis, Protocol::Redis.

--- a/XS.xs
+++ b/XS.xs
@@ -1,11 +1,11 @@
 #define PERL_NO_GET_CONTEXT
 
-#include "hiredis.h"
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
 #include "ppport.h"
 #include <xs_object_magic.h>
+#include <hiredis.h>
 
 #ifdef PERL_IMPLICIT_CONTEXT
 

--- a/lib/Protocol/Redis/XS.pm
+++ b/lib/Protocol/Redis/XS.pm
@@ -104,12 +104,6 @@ L<#redis on irc.perl.org|irc://irc.perl.org/redis>
 
 See github: L<https://github.com/dgl/protocol-redis-xs>.
 
-Developer note, hiredis is pulled in via a git submodule, run:
-
- git submodule update --init
-
-to make the development version buildable.
-
 =head1 AUTHOR
 
 David Leadbeater <dgl@dgl.cx>
@@ -126,9 +120,6 @@ the terms of either: the GNU General Public License as published
 by the Free Software Foundation; or the Artistic License.
 
 See http://dev.perl.org/licenses/ for more information.
-
-The hiredis library included in this distribution has a seperate license (3
-clause BSD). See F<hiredis/COPYING>.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Alien::hiredis provides an abstraction to build against either a system hiredis library if appropriate, or a share-built version. This will require a new enough version of hiredis to solve #5, and allow for the library version to be managed separately from this distribution in general.