### PR TITLE
support hiredis >= 1.0

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -114,7 +114,9 @@ static void *createDoubleObjectSV(const redisReadTask *task, double value,
   dTHXREDIS(task);
 
   SV *sv = newSVpvn(str, len);
-  sv_setnv(sv, value);
+  SvUPGRADE(sv, SVt_PVNV);
+  SvNV_set(sv, value);
+  SvNOK_on(sv);
   SV *const reply = createReply(aTHX_ sv, task->type);
   storeParent(aTHX_ task, reply);
   return reply;


### PR DESCRIPTION
i'm on a system with hiredis 1.0.2 installed. i ran into problems with Protocol::Redis::XS (segfaults and "bizarre copy of UNKNOWN" errors from perl), so i hacked some stuff together to get it working with the newer version.

i have pretty much no idea what i'm doing in XS, so please review carefully. this change "works for me," but it's likely i've done horrible things i'm unaware of. i added #if guards around the changes to hopefully keep it working on older versions of hiredis, but haven't been able to test that.

hope it's helpful.