### PR TITLE
fix memory leak when encoding bad data

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -316,7 +316,8 @@ get_message(redisReader *r)
 SV*
 encode(SV *self, SV *message)
   CODE:
-    RETVAL = newSVpvn("", 0);
+    RETVAL = sv_2mortal(newSVpvn("", 0));
     encodeMessage(aTHX_ RETVAL, message);
+    SvREFCNT_inc(RETVAL);
   OUTPUT:
     RETVAL

--- a/xt/author/leaktest.t
+++ b/xt/author/leaktest.t
@@ -8,26 +8,65 @@ sub count_arena { my $arena = walk_arena; my $count = @$arena; @$arena = (); ret
 
 my $protocol = Protocol::Redis::XS->new(api => 1);
 
-my $input = {
-  'type' => '*',
-  'data' => [
-    {
-      'type' => '$',
-      'data' => 'GET'
-    },
-    {
-      'data' => 'cool:key',
-      'type' => '$'
-    }
-  ]
-};
-
 my $start_count = count_arena;
+{
+  my $input = {
+    'type' => '*',
+    'data' => [
+      {
+        'type' => '$',
+        'data' => 'GET'
+      },
+      {
+        'data' => 'cool:key',
+        'type' => '$'
+      }
+    ]
+  };
 
-$protocol->encode($input);
 
+  $protocol->encode($input);
+}
 my $end_count = count_arena;
 
-is $end_count, $start_count, 'no memory leak';
+is $end_count, $start_count, 'no memory leak while encoding nested structure';
+
+$start_count = count_arena;
+{
+  my $input = {
+    'type' => '*',
+    'data' => [
+      {
+        'type' => '$',
+        'data' => 'GET',
+      },
+      {
+        type => '*',
+        data => [
+          {
+            'data' => 'cool:key',
+            'type' => '$',
+          },
+          {
+            type => '*',
+            data => [
+              {
+                data => '',
+                type => 'bogus',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+  };
+
+  eval {
+    $protocol->encode($input);
+  };
+}
+$end_count = count_arena;
+
+is $end_count, $start_count, 'no memory leak while encoding nested structure with errors';
 
 done_testing;


### PR DESCRIPTION
Since d696d70cd44f8, encoding a data structure with invalid `type` fields always leaks one SV when it throws an error. (Previously, it would not leak when encoding a single data field, but leak multiple SVs when encoding nested structures (`type => '*'`).)

Fix: Mark RETVAL as "mortal" (temporary) initially, so if encodeMessage() throws, RETVAL will be freed. But if encodeMessage() returns successfully, we have to undo that (otherwise RETVAL will be freed twice), so just bump the reference count artifically (to be consumed by the mortalizing machinery).