### PR TITLE
Throw an exception on unknown API version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ my %WriteMakefile_args = (
   PREREQ_PM => {
     'XSLoader' => 0,
     'XS::Object::Magic' => 0,
-    'Protocol::Redis' => '1.0011',
+    'Protocol::Redis' => '1.0020',
     'parent' => 0,
   },
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ my %WriteMakefile_args = (
   PREREQ_PM => {
     'XSLoader' => 0,
     'XS::Object::Magic' => 0,
-    'Protocol::Redis' => '1.0020',
+    'Protocol::Redis' => '1.0021',
     'parent' => 0,
   },
 

--- a/lib/Protocol/Redis/XS.pm
+++ b/lib/Protocol/Redis/XS.pm
@@ -16,7 +16,8 @@ sub new {
   my $on_message = delete $args{on_message};
 
   my $self = bless \%args, $class;
-  return undef unless $self->api == 1;
+  Carp::croak(qq/Unknown Protocol::Redis API version $self->{api}/)
+    unless $self->api == 1;
   $self->on_message($on_message) if defined $on_message;
 
   $self->_create;


### PR DESCRIPTION
We changed Protocol::Redis API to throw an exception on unknown version, it is a slight change, and user code should not be affected by the change, still it is nice to adapt the change in all implementations